### PR TITLE
Send formatVersion against PATCH endpoint

### DIFF
--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -92,6 +92,7 @@ export class ApiService {
     }));
     const wcifToSend = {
       id: wcif.id,
+      formatVersion: wcif.formatVersion,
       schedule: wcif.schedule,
       persons: persons,
     };

--- a/src/common/classes.ts
+++ b/src/common/classes.ts
@@ -4,6 +4,7 @@ export class Wcif {
   persons?: Array<any>;
   events?: Array<any>;
   id?: any;
+  formatVersion?: string;
   name?: string;
   schedule?: Schedule;
   extensions?: any[];


### PR DESCRIPTION
With recent Dual Round changes, we introduced a new WCIF version along with general versioning.

As a consequence, the `PATCH` endpoint now needs to know what version it is being `PATCH`ed from, so I'm just sending the original WCIF version that came from the fetch through.